### PR TITLE
Update Nokogiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Main (unreleased)
+
+* Updated nokogiri dependency from (~> 1.10.1 to ~> 1.11.4)
+
 ## 1.0.1 (2019-02-05)
 
 * Updated nokogiri dependency from (~>1.8.1 to ~>1.10.1)

--- a/slack_transformer.gemspec
+++ b/slack_transformer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     *Dir['lib/slack_transformer/slack/*.rb']
   ]
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.10.1'
+  s.add_runtime_dependency 'nokogiri', '~> 1.11.4'
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
 end


### PR DESCRIPTION
Updated Nokogiri dependency to `~> 1.11.4`

Verified that tests are passing and manually tested the gem in a rails project using Nokogiri 1.11.7