### PR TITLE
Fix Codacy linting errors

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "remark-preset-lint-recommended",
+    ["remark-lint-list-item-indent", "space"]
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Main (unreleased)
 
 * Updated nokogiri dependency from (~> 1.10.1 to ~> 1.11.4)
+* Add remark configuration and address lint errors
 
 ## 1.0.1 (2019-02-05)
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ SlackTransformer::Slack.new('*_important stuff_*').to_html
 
 Each transformation can also be applied individually.
 
-
 ### Bold
 
 ```ruby

--- a/lib/slack_transformer/slack.rb
+++ b/lib/slack_transformer/slack.rb
@@ -25,8 +25,8 @@ module SlackTransformer
     end
 
     def to_html
-      html = TRANSFORMERS.reduce(input) do |html, transformer|
-        transformer.new(html).to_html
+      html = TRANSFORMERS.reduce(input) do |working_html, transformer|
+        transformer.new(working_html).to_html
       end
 
       "<p>#{html.gsub("\n", '<br>')}</p>"


### PR DESCRIPTION
Including changing the remark configuration to expect a single space after a list item bullet