### PR TITLE
Allow upgrades within the 1.x major version of Nokogiri

### DIFF
--- a/slack_transformer.gemspec
+++ b/slack_transformer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     *Dir['lib/slack_transformer/slack/*.rb']
   ]
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.11.4'
+  s.add_runtime_dependency 'nokogiri', '~> 1.11'
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
 end


### PR DESCRIPTION
1.13, in particular, adds native gem support for Ruby 3.1, and since it follows Semantic Versioning ([here](https://github.com/sparklemotion/nokogiri#semantic-versioning-policy)), it should be safe to allow minor version upgrades!

It'd be awesome to get a new release with this change, if it's approved+merged, to improve the Ruby 3.1 upgrade path for folks!