### PR TITLE
LBX-2894 bump nokogiri version for ruby 3.2 support

### DIFF
--- a/slack_transformer.gemspec
+++ b/slack_transformer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     *Dir['lib/slack_transformer/slack/*.rb']
   ]
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.11.4'
+  s.add_runtime_dependency 'nokogiri', '~> 1.14.0'
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
 end


### PR DESCRIPTION
Bumps nokogiri dependency due to incompatibility with newer versions of ruby