### PR TITLE
VKG-3367 loosen restriction on nokogiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change log
+## 1.0.4 (2023-08-14)
+
+* Updated nokogiri dependency from (~> 1.14.0 to < 2.0) for flexibility
 
 ## 1.0.3 (2023-02-14)
 

--- a/slack_transformer.gemspec
+++ b/slack_transformer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     *Dir['lib/slack_transformer/slack/*.rb']
   ]
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.14.0'
+  s.add_runtime_dependency 'nokogiri', '< 2.0'
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
 end


### PR DESCRIPTION
Updated nokogiri dependency to be < 2.0.
Decided on a looser target due to the frequency of nokogiri updates and low likelihood of this gem's uses being affected by removed functionality
