### PR TITLE
Add support for hyperlinks and nested lists

### DIFF
--- a/lib/slack_transformer/html.rb
+++ b/lib/slack_transformer/html.rb
@@ -1,5 +1,6 @@
 require 'slack_transformer/html/bold'
 require 'slack_transformer/html/code'
+require 'slack_transformer/html/hyperlinks'
 require 'slack_transformer/html/italics'
 require 'slack_transformer/html/lists'
 require 'slack_transformer/html/preformatted'
@@ -10,12 +11,14 @@ module SlackTransformer
     attr_reader :input
 
     TRANSFORMERS = [
+      # Need to use the transformers using Nokogiri first before using gsub.
+      SlackTransformer::Html::Lists,
       SlackTransformer::Html::Bold,
       SlackTransformer::Html::Italics,
       SlackTransformer::Html::Strikethrough,
       SlackTransformer::Html::Code,
       SlackTransformer::Html::Preformatted,
-      SlackTransformer::Html::Lists
+      SlackTransformer::Html::Hyperlinks
     ]
 
     def initialize(input)

--- a/lib/slack_transformer/html/hyperlinks.rb
+++ b/lib/slack_transformer/html/hyperlinks.rb
@@ -1,0 +1,32 @@
+require 'nokogiri'
+
+module SlackTransformer
+  class Html
+    class Hyperlinks
+      attr_reader :input
+
+      def initialize(input)
+        @input = input
+      end
+
+      def to_slack
+        fragment = Nokogiri::HTML.fragment(input)
+
+        links_to_replace = {}
+        fragment.children.each do |child|
+          if child.name == 'a'
+            hyperlink_text = child.text.empty? ? child.attr('href') : child.text
+            hyperlink = "<#{child.attr('href')}|#{hyperlink_text}>"
+            links_to_replace[child.to_s] = hyperlink
+          end
+        end
+
+        links_to_replace.each do |html, hyperlink|
+          input.gsub!(html, hyperlink)
+        end
+
+      input
+      end
+    end
+  end
+end

--- a/lib/slack_transformer/html/lists.rb
+++ b/lib/slack_transformer/html/lists.rb
@@ -15,21 +15,40 @@ module SlackTransformer
         fragment.children.each do |child|
           case child.name
           when 'ul'
-            list = child.children.map do |c|
-              "• #{c.children.to_html}"
-            end
-
-            child.replace(list.join("\n"))
+            child.replace(indent_nested_list(child)))
           when 'ol'
-            list = child.children.map.with_index do |c, i|
-              "#{i + 1}. #{c.children.to_html}"
-            end
-
-            child.replace(list.join("\n"))
+            child.replace(indent_nested_number_list(child))
           end
         end
 
         fragment.to_html
+      end
+
+      def indent_nested_list(child, num_indent = 0)
+        child.children.map do |c|
+
+          case c.name
+          when 'li'
+            indent_nested_list(c, num_indent)
+          when 'ul'
+            indent_nested_list(c, num_indent += 1)
+          else
+            "#{"\t" * num_indent}• #{c.to_html}"
+          end
+        end.join("\n")
+      end
+
+      def indent_nested_number_list(child, num_indent = 0, index = 0)
+        child.children.map do |c|
+          case c.name
+          when 'li'
+            indent_nested_number_list(c, num_indent, index += 1)
+          when 'ol'
+            indent_nested_number_list(c, num_indent += 1, 0)
+          else
+            "#{"\t" * num_indent}#{index}. #{c.to_html}"
+          end
+        end.join("\n")
       end
     end
   end

--- a/lib/slack_transformer/html/lists.rb
+++ b/lib/slack_transformer/html/lists.rb
@@ -15,7 +15,7 @@ module SlackTransformer
         fragment.children.each do |child|
           case child.name
           when 'ul'
-            child.replace(indent_nested_list(child)))
+            child.replace(indent_nested_list(child))
           when 'ol'
             child.replace(indent_nested_number_list(child))
           end

--- a/spec/slack_transformer/html/hyperlinks_spec.rb
+++ b/spec/slack_transformer/html/hyperlinks_spec.rb
@@ -1,0 +1,21 @@
+require 'slack_transformer/html/hyperlinks'
+
+RSpec.describe SlackTransformer::Html::Hyperlinks do
+  let(:transformation) { described_class.new(input) }
+
+  describe '#to_slack' do
+    context 'when hyperlink text is present' do
+      let(:input) { '<a href="test.com">test link</a>' }
+      it 'replaces HTML a Tag with slack hyperlink' do
+          expect(transformation.to_slack).to eq('<test.com|test link>')
+      end
+    end
+
+    context 'when hyperlink text is not present' do
+      let(:input) { '<a href="test.com"></a>' }
+      it 'uses the href as the hyperlink text' do
+        expect(transformation.to_slack).to eq('<test.com|test.com>')
+      end
+    end
+  end
+end

--- a/spec/slack_transformer/html/lists_spec.rb
+++ b/spec/slack_transformer/html/lists_spec.rb
@@ -12,11 +12,27 @@ RSpec.describe SlackTransformer::Html::Lists do
       end
     end
 
+    context 'when a nested list is unordered' do
+      let(:input) { '<ul><li>foo<ul><li>bar<ul><li>baz</li></ul></ul></ul>' }
+
+      it 'replaces the list' do
+        expect(transformation.to_slack).to eq("• foo\n\t• bar\n\t\t• baz")
+      end
+    end
+
     context 'when a list is ordered' do
       let(:input) { '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' }
 
       it 'replaces the list' do
         expect(transformation.to_slack).to eq("1. foo\n2. bar\n3. baz")
+      end
+    end
+
+    context 'when a nested list is ordered' do
+      let(:input) { '<ol><li>foo<ol><li>bar<ol><li>baz</li></ol></ol></ol>' }
+
+      it 'replaces the list' do
+        expect(transformation.to_slack).to eq("1. foo\n\t1. bar\n\t\t1. baz")
       end
     end
   end


### PR DESCRIPTION
Add support for hyperlinks and nested lists

Hyperlinks -> turns a tags to slack mrkdwn
`<a href="www.example.com">Test</a>` -> `<www.example.com|Test>`

Nested lists:
Unordered lists, subbullet points are added with tabs
`<ul><li>foo<ul><li>bar<ul><li>baz</li></ul></ul></ul>` -> `• foo\n\t• bar\n\t\t• baz`
Ordered lists - subbullet points start over from 1, 2, 3...
`<ol><li>foo<ol><li>bar<ol><li>baz</li></ol></ol></ol>` -> `1. foo\n\t1. bar\n\t\t1. baz`